### PR TITLE
Fix enemy velocity property

### DIFF
--- a/Assets/_Project/Scripts/Enemies/EnemyAdvancedAI.cs
+++ b/Assets/_Project/Scripts/Enemies/EnemyAdvancedAI.cs
@@ -33,7 +33,7 @@ public class EnemyAdvancedAI : MonoBehaviour
             destino = jogador;
         }
         Vector2 dir = (destino.position - transform.position).normalized;
-        rb.linearVelocity = new Vector2(dir.x * velocidade, rb.linearVelocity.y);
+        rb.velocity = new Vector2(dir.x * velocidade, rb.velocity.y);
         if (animator) animator.SetFloat("Velocidade", Mathf.Abs(dir.x));
         transform.localScale = new Vector3(Mathf.Sign(dir.x), 1, 1);
     }

--- a/Assets/_Project/Scripts/Enemies/EnemyPatrol.cs
+++ b/Assets/_Project/Scripts/Enemies/EnemyPatrol.cs
@@ -17,7 +17,7 @@ public class EnemyPatrol : MonoBehaviour
         if (pontosPatrulha.Length == 0) return;
         Transform alvo = pontosPatrulha[indice];
         Vector2 dir = (alvo.position - transform.position).normalized;
-        rb.linearVelocity = new Vector2(dir.x * velocidade, rb.linearVelocity.y);
+        rb.velocity = new Vector2(dir.x * velocidade, rb.velocity.y);
         if (Vector2.Distance(transform.position, alvo.position) < 0.2f)
             indice = (indice + 1) % pontosPatrulha.Length;
     }


### PR DESCRIPTION
## Summary
- use `velocity` instead of `linearVelocity` in Enemy AI scripts

## Testing
- `grep -R "linearVelocity" -n`

------
https://chatgpt.com/codex/tasks/task_e_68634e55ea748323b799b554a92de109