### PR TITLE
Fix ScoreManager persistence

### DIFF
--- a/Assets/_Project/Scripts/ScoreManager.cs
+++ b/Assets/_Project/Scripts/ScoreManager.cs
@@ -10,7 +10,11 @@ public class ScoreManager : MonoBehaviour
 
     void Awake()
     {
-        if (instance == null) instance = this;
+        if (instance == null)
+        {
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
         else Destroy(gameObject);
     }
 


### PR DESCRIPTION
## Summary
- persist ScoreManager singleton across scene loads

## Testing
- `curl -I https://example.com`

------
https://chatgpt.com/codex/tasks/task_e_68634e56e59883239fe66c9a82123c9e