### PR TITLE
Add playable scenes to EditorBuildSettings

### DIFF
--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -4,6 +4,21 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+    - enabled: 1
+      path: Assets/_Project/Scenes/MainMenu.unity
+      guid: 878f25a98dd5bfa49bac3e29afbe03a4
+    - enabled: 1
+      path: Assets/_Project/Scenes/FaseDeserto.unity
+      guid: a6f14ea926d8a0b429bf5dd6ea42500e
+    - enabled: 1
+      path: Assets/_Project/Scenes/LojaEntreFases.unity
+      guid: edd0ee5d25928da4ab73ca2b4751a615
+    - enabled: 1
+      path: Assets/_Project/Scenes/FaseMontanha.unity
+      guid: 44767a4e5657dec46912b109ef74a54a
+    - enabled: 1
+      path: Assets/_Project/Scenes/FaseGelo.unity
+      guid: bc97fe6ec7ed2ef4c87211c41a6c7b83
   m_configObjects: {}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
## Summary
- include scenes like MainMenu, FaseDeserto and LojaEntreFases in Unity build settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68634e57abd88323aaa2bd25105cc4b3