### PR TITLE
Fix scene names in GameManager

### DIFF
--- a/Assets/_Project/Scripts/Systems/GameManager.cs
+++ b/Assets/_Project/Scripts/Systems/GameManager.cs
@@ -31,7 +31,7 @@ public class GameManager : MonoBehaviour
         CurrentDifficulty = difficulty;
         scoreMultiplier = DifficultyMultiplier(difficulty);
         ChangeState(GameState.Jogando);
-        SceneManager.LoadScene("Fase1_Deserto");
+        SceneManager.LoadScene("FaseDeserto");
     }
 
     public void ChangeState(GameState newState)
@@ -42,7 +42,7 @@ public class GameManager : MonoBehaviour
     public void LoadShop()
     {
         ChangeState(GameState.Loja);
-        SceneManager.LoadScene("Loja");
+        SceneManager.LoadScene("LojaEntreFases");
     }
 
     float DifficultyMultiplier(Difficulty diff)


### PR DESCRIPTION
## Summary
- update GameManager to use correct scene names

## Testing
- `npm test` *(fails: could not find package.json)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656fd4143883239a99ac121a5e0228