### PR TITLE
Add save/load game slots

### DIFF
--- a/Assets/_Project/Scripts/ScoreManager.cs
+++ b/Assets/_Project/Scripts/ScoreManager.cs
@@ -54,6 +54,12 @@ public class ScoreManager : MonoBehaviour
         AtualizarUI();
     }
 
+    public void SetPontos(int valor)
+    {
+        pontos = valor;
+        AtualizarUI();
+    }
+
     void AtualizarUI()
     {
         if (textoPontos) textoPontos.text = "PONTOS: " + pontos;

--- a/Assets/_Project/Scripts/Systems/GameManager.cs
+++ b/Assets/_Project/Scripts/Systems/GameManager.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using System.Collections;
 
 public class GameManager : MonoBehaviour
 {
@@ -12,6 +13,9 @@ public class GameManager : MonoBehaviour
     public Difficulty CurrentDifficulty { get; private set; } = Difficulty.Normal;
 
     public float scoreMultiplier { get; private set; } = 1f;
+
+    int pendingScore = -1;
+    const int startSceneIndex = 1; // FaseDeserto
 
     void Awake()
     {
@@ -26,12 +30,34 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    public void StartGame(Difficulty difficulty)
+    void OnEnable()
+    {
+        SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    void OnDisable()
+    {
+        SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+    public void StartGame(Difficulty difficulty, int slot)
     {
         CurrentDifficulty = difficulty;
         scoreMultiplier = DifficultyMultiplier(difficulty);
+
+        var data = LoadGame(slot);
+        if (data != null)
+        {
+            pendingScore = data.pontos;
+        }
+        else
+        {
+            pendingScore = 0;
+        }
+
         ChangeState(GameState.Jogando);
-        SceneManager.LoadScene("FaseDeserto");
+        int scene = data != null ? data.faseAtual : startSceneIndex;
+        SceneManager.LoadScene(scene);
     }
 
     public void ChangeState(GameState newState)
@@ -43,6 +69,37 @@ public class GameManager : MonoBehaviour
     {
         ChangeState(GameState.Loja);
         SceneManager.LoadScene("LojaEntreFases");
+    }
+
+    public void SaveGame(int slot)
+    {
+        var data = new SaveData
+        {
+            faseAtual = SceneManager.GetActiveScene().buildIndex,
+            pontos = ScoreManager.instance ? ScoreManager.instance.pontos : 0,
+            dificuldade = CurrentDifficulty
+        };
+        SaveSystem.Save(slot, data);
+    }
+
+    public SaveData LoadGame(int slot)
+    {
+        var data = SaveSystem.Load(slot);
+        if (data != null)
+        {
+            CurrentDifficulty = data.dificuldade;
+            scoreMultiplier = DifficultyMultiplier(CurrentDifficulty);
+        }
+        return data;
+    }
+
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        if (pendingScore >= 0 && ScoreManager.instance != null)
+        {
+            ScoreManager.instance.SetPontos(pendingScore);
+            pendingScore = -1;
+        }
     }
 
     float DifficultyMultiplier(Difficulty diff)

--- a/Assets/_Project/Scripts/Systems/MenuManager.cs
+++ b/Assets/_Project/Scripts/Systems/MenuManager.cs
@@ -3,14 +3,24 @@ using UnityEngine.SceneManagement;
 
 public class MenuManager : MonoBehaviour
 {
-    public void Jogar()
+    public void Jogar(int slot)
     {
-        SceneManager.LoadScene("FaseDeserto");
+        GameManager.Instance.StartGame(GameManager.Difficulty.Normal, slot);
     }
 
     public void MostrarLoja()
     {
         SceneManager.LoadScene("LojaEntreFases");
+    }
+
+    public void Salvar(int slot)
+    {
+        GameManager.Instance.SaveGame(slot);
+    }
+
+    public void Carregar(int slot)
+    {
+        GameManager.Instance.StartGame(GameManager.Difficulty.Normal, slot);
     }
 
     public void Sair()


### PR DESCRIPTION
## Summary
- support saving/loading by slot in `GameManager`
- expose slot handling through `MenuManager`
- allow `ScoreManager` to set points directly

## Testing
- `npm test` *(fails: package.json missing)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686570d340688323bcbaf0b3fefbfd8c