### PR TITLE
Implement comprehensive GameManager states

### DIFF
--- a/Assets/_Project/Scripts/Bosses/BossColossoInstavel.cs
+++ b/Assets/_Project/Scripts/Bosses/BossColossoInstavel.cs
@@ -47,6 +47,7 @@ public class BossColossoInstavel : MonoBehaviour
     void Morrer()
     {
         Destroy(gameObject);
-        GameFlowManager.instancia?.Avancar();
+        if (GameManager.Instance != null)
+            GameManager.Instance.NextPhase();
     }
 }

--- a/Assets/_Project/Scripts/Bosses/BossControllerDeserto.cs
+++ b/Assets/_Project/Scripts/Bosses/BossControllerDeserto.cs
@@ -41,6 +41,7 @@ public class BossControllerDeserto : MonoBehaviour
     void Morrer()
     {
         Destroy(gameObject);
-        GameFlowManager.instancia?.Avancar();
+        if (GameManager.Instance != null)
+            GameManager.Instance.NextPhase();
     }
 }

--- a/Assets/_Project/Scripts/Effects/GameEffectsManager.cs
+++ b/Assets/_Project/Scripts/Effects/GameEffectsManager.cs
@@ -39,7 +39,17 @@ public class GameEffectsManager : MonoBehaviour
     public void AlternarPausa()
     {
         pausado = !pausado;
-        Time.timeScale = pausado ? 0 : 1;
+        if (GameManager.Instance != null)
+        {
+            if (pausado)
+                GameManager.Instance.PauseGame();
+            else
+                GameManager.Instance.ResumeGame();
+        }
+        else
+        {
+            Time.timeScale = pausado ? 0 : 1;
+        }
         if (menuPausa != null) menuPausa.SetActive(pausado);
         Debug.Log("Jogo " + (pausado ? "Pausado" : "Despausado"));
     }

--- a/Assets/_Project/Scripts/Player/PlayerHealth.cs
+++ b/Assets/_Project/Scripts/Player/PlayerHealth.cs
@@ -37,6 +37,8 @@ public class PlayerHealth : MonoBehaviour
     void Die()
     {
         onDeath?.Invoke();
+        if (GameManager.Instance != null)
+            GameManager.Instance.EnterGameOver();
         gameObject.SetActive(false);
     }
 }

--- a/Assets/_Project/Scripts/Systems/GameManager.cs
+++ b/Assets/_Project/Scripts/Systems/GameManager.cs
@@ -11,6 +11,7 @@ public class GameManager : MonoBehaviour
 
     public GameState State { get; private set; } = GameState.MenuInicial;
     public Difficulty CurrentDifficulty { get; private set; } = Difficulty.Normal;
+    public int CurrentSlot { get; private set; } = 0;
 
     public float scoreMultiplier { get; private set; } = 1f;
 
@@ -46,8 +47,8 @@ public class GameManager : MonoBehaviour
         {
             ScoreManager.instance.Reset();
         }
-        CurrentDifficulty = difficulty;
-        scoreMultiplier = DifficultyMultiplier(difficulty);
+        SelectDifficulty(difficulty);
+        CurrentSlot = slot;
 
         var data = LoadGame(slot);
         if (data != null)
@@ -69,10 +70,92 @@ public class GameManager : MonoBehaviour
         State = newState;
     }
 
-    public void LoadShop()
+    public void SelectDifficulty(Difficulty difficulty)
+    {
+        CurrentDifficulty = difficulty;
+        scoreMultiplier = DifficultyMultiplier(difficulty);
+    }
+
+    public void EnterMenuInicial(int slot = 0)
+    {
+        CurrentSlot = slot;
+        ChangeState(GameState.MenuInicial);
+        SceneManager.LoadScene("MainMenu");
+        LoadGame(CurrentSlot);
+    }
+
+    public void StartGameplay()
+    {
+        ChangeState(GameState.Jogando);
+        Time.timeScale = 1f;
+        SceneManager.LoadScene(startSceneIndex);
+    }
+
+    public void PauseGame()
+    {
+        if (State == GameState.Pausado) return;
+        ChangeState(GameState.Pausado);
+        Time.timeScale = 0f;
+    }
+
+    public void ResumeGame()
+    {
+        if (State != GameState.Pausado) return;
+        ChangeState(GameState.Jogando);
+        Time.timeScale = 1f;
+    }
+
+    public void EnterUpgrade()
+    {
+        ChangeState(GameState.Upgrade);
+    }
+
+    public void EnterGameOver()
+    {
+        ChangeState(GameState.GameOver);
+        Time.timeScale = 1f;
+        SaveGame(CurrentSlot);
+        SceneManager.LoadScene("GameOver");
+    }
+
+    public void EnterVitoria()
+    {
+        ChangeState(GameState.Vitoria);
+        Time.timeScale = 1f;
+        SaveGame(CurrentSlot);
+        SceneManager.LoadScene("Vitoria");
+    }
+
+    public void EnterShop()
     {
         ChangeState(GameState.Loja);
         SceneManager.LoadScene("LojaEntreFases");
+    }
+
+    public void EnterModoHorda()
+    {
+        ChangeState(GameState.ModoHorda);
+        SceneManager.LoadScene("TesteJogabilidade");
+    }
+
+    public void NextPhase()
+    {
+        int next = SceneManager.GetActiveScene().buildIndex + 1;
+        if (next >= SceneManager.sceneCountInBuildSettings)
+        {
+            EnterMenuInicial(CurrentSlot);
+        }
+        else
+        {
+            SaveGame(CurrentSlot);
+            SceneManager.LoadScene(next);
+            ChangeState(GameState.Jogando);
+        }
+    }
+
+    public void LoadShop()
+    {
+        EnterShop();
     }
 
     public void SaveGame(int slot)


### PR DESCRIPTION
## Summary
- extend `GameManager` with state-handling methods
- allow selecting difficulty and track save slot
- integrate pause/resume with `GameEffectsManager`
- trigger game over through `PlayerHealth`
- move boss level progression through `GameManager`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865dd4141148323ad8de29854dba793