### PR TITLE
Implement enemy AI state machine

### DIFF
--- a/Assets/_Project/Scripts/Enemies/EnemyAdvancedAI.cs
+++ b/Assets/_Project/Scripts/Enemies/EnemyAdvancedAI.cs
@@ -2,29 +2,76 @@ using UnityEngine;
 
 public class EnemyAdvancedAI : MonoBehaviour
 {
+    public enum EnemyState { Patrol, Chase, Attack, Die }
+
     public Transform jogador;
     public float velocidade = 2.5f;
+    public float chaseDistance = 5f;
+    public float attackDistance = 1.2f;
     public float distanciaStop = 2f;
     public Transform[] pontosAlternativos;
 
     private Rigidbody rb;
     private Animator animator;
+    private EnemyPatrol patrol;
+    private EnemyAttack enemyAttack;
+    private EnemyHealth health;
     private Transform destino;
+    private EnemyState state = EnemyState.Patrol;
 
     void Start()
     {
         rb = GetComponent<Rigidbody>();
         animator = GetComponent<Animator>();
-        destino = pontosAlternativos.Length>0? pontosAlternativos[0] : jogador;
+        patrol = GetComponent<EnemyPatrol>();
+        enemyAttack = GetComponent<EnemyAttack>();
+        health = GetComponent<EnemyHealth>();
+        destino = jogador;
+        ChangeState(state);
     }
 
     void Update()
     {
         if (jogador == null) return;
-        float d = Vector3.Distance(transform.position, jogador.position);
-        if (d < distanciaStop)
+
+        if (health && health.IsDead)
         {
-            // escolhe rota alternativa
+            ChangeState(EnemyState.Die);
+        }
+
+        switch (state)
+        {
+            case EnemyState.Patrol:
+                if (Vector3.Distance(transform.position, jogador.position) <= chaseDistance)
+                    ChangeState(EnemyState.Chase);
+                break;
+
+            case EnemyState.Chase:
+                HandleChase();
+                float dist = Vector3.Distance(transform.position, jogador.position);
+                if (dist <= attackDistance)
+                    ChangeState(EnemyState.Attack);
+                else if (dist > chaseDistance)
+                    ChangeState(EnemyState.Patrol);
+                break;
+
+            case EnemyState.Attack:
+                FaceTarget();
+                if (Vector3.Distance(transform.position, jogador.position) > attackDistance)
+                    ChangeState(EnemyState.Chase);
+                break;
+
+            case EnemyState.Die:
+                rb.velocity = Vector3.zero;
+                break;
+        }
+    }
+
+    void HandleChase()
+    {
+        float d = Vector3.Distance(transform.position, jogador.position);
+        if (d < distanciaStop && pontosAlternativos.Length > 0)
+        {
             int idx = Random.Range(0, pontosAlternativos.Length);
             destino = pontosAlternativos[idx];
         }
@@ -32,9 +79,25 @@ public class EnemyAdvancedAI : MonoBehaviour
         {
             destino = jogador;
         }
+
         Vector3 dir = (destino.position - transform.position).normalized;
         rb.velocity = new Vector3(dir.x * velocidade, rb.velocity.y, dir.z * velocidade);
         if (animator) animator.SetFloat("Velocidade", Mathf.Abs(dir.x));
         transform.localScale = new Vector3(Mathf.Sign(dir.x), 1, 1);
+    }
+
+    void FaceTarget()
+    {
+        Vector3 dir = (jogador.position - transform.position).normalized;
+        transform.localScale = new Vector3(Mathf.Sign(dir.x), 1, 1);
+        rb.velocity = Vector3.zero;
+    }
+
+    void ChangeState(EnemyState newState)
+    {
+        if (state == newState) return;
+        state = newState;
+        if (patrol) patrol.enabled = state == EnemyState.Patrol;
+        if (enemyAttack) enemyAttack.enabled = state == EnemyState.Attack;
     }
 }

--- a/Assets/_Project/Scripts/Enemies/EnemyHealth.cs
+++ b/Assets/_Project/Scripts/Enemies/EnemyHealth.cs
@@ -6,6 +6,8 @@ public class EnemyHealth : MonoBehaviour
     public int vidaMaxima = 50;
     private int vidaAtual;
 
+    public bool IsDead => vidaAtual <= 0;
+
     [Header("Feedback Visual")]
     public GameObject fxDano;
     public GameObject fxMorte;


### PR DESCRIPTION
## Summary
- expose `EnemyHealth.IsDead` helper
- add state machine to `EnemyAdvancedAI` with Patrol, Chase, Attack and Die states
- enable/disable existing patrol and attack behaviours based on state

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e63376d48323b8cd768d1371bb03