### PR TITLE
Add Explosion FX and update enemy damage effects

### DIFF
--- a/Assets/_Project/Scripts/Enemies/EnemyHealth.cs
+++ b/Assets/_Project/Scripts/Enemies/EnemyHealth.cs
@@ -30,7 +30,7 @@ public class EnemyHealth : MonoBehaviour
         vidaAtual -= dano;
 
         if (FXManager.Instance != null)
-            FXManager.Instance.PlayBlood(transform.position);
+            FXManager.Instance.Play(FXManager.FXType.Blood, transform.position);
 
         StartCoroutine(FlashDano());
 
@@ -51,7 +51,7 @@ public class EnemyHealth : MonoBehaviour
     void Morrer()
     {
         if (FXManager.Instance != null)
-            FXManager.Instance.PlayExplosion(transform.position);
+            FXManager.Instance.Play(FXManager.FXType.Explosion, transform.position);
 
         // Adiciona pontuação
         if (ScoreManager.instance != null)

--- a/Assets/_Project/Scripts/FX/FXManager.cs
+++ b/Assets/_Project/Scripts/FX/FXManager.cs
@@ -16,6 +16,7 @@ public class FXManager : MonoBehaviour
         Blood,
         Snow,
         EscudoColosso,
+        Explosion,
         // Outros efeitos podem ser adicionados aqui
     }
 
@@ -41,6 +42,7 @@ public class FXManager : MonoBehaviour
         Register(FXType.Blood, (p, r, parent) => CreateSimpleParticles("BloodFX", p, r, parent, Color.red, 1f, 30));
         Register(FXType.Snow, (p, r, parent) => CreateSimpleParticles("SnowFX", p, r, parent, Color.white, 2f, 10));
         Register(FXType.EscudoColosso, (p, r, parent) => CreateShield(p, r, parent));
+        Register(FXType.Explosion, (p, r, parent) => CreateSimpleParticles("ExplosionFX", p, r, parent, new Color(1f, 0.5f, 0f), 1f, 40));
     }
 
     public void Register(FXType type, Func<Vector3, Quaternion, Transform, GameObject> builder)


### PR DESCRIPTION
## Summary
- extend `FXManager.FXType` with a new `Explosion` entry
- register a basic explosion particle effect in `FXManager`
- use `FXManager.Play` in `EnemyHealth` for blood and explosion effects
