### PR TITLE
Add energy UI support

### DIFF
--- a/Assets/_Project/Scripts/Player/PlayerEnergy.cs
+++ b/Assets/_Project/Scripts/Player/PlayerEnergy.cs
@@ -7,9 +7,12 @@ public class PlayerEnergy : MonoBehaviour
     public int currentEnergy;
     public float regenRate = 10f;
 
+    public event System.Action<int> OnEnergyChanged;
+
     void Awake()
     {
         currentEnergy = maxEnergy;
+        OnEnergyChanged?.Invoke(currentEnergy);
     }
 
     void Update()
@@ -19,6 +22,7 @@ public class PlayerEnergy : MonoBehaviour
             currentEnergy += Mathf.CeilToInt(regenRate * Time.deltaTime);
             if (currentEnergy > maxEnergy)
                 currentEnergy = maxEnergy;
+            OnEnergyChanged?.Invoke(currentEnergy);
         }
     }
 
@@ -28,11 +32,13 @@ public class PlayerEnergy : MonoBehaviour
             return false;
 
         currentEnergy -= amount;
+        OnEnergyChanged?.Invoke(currentEnergy);
         return true;
     }
 
     public void Restore(int amount)
     {
         currentEnergy = Mathf.Clamp(currentEnergy + amount, 0, maxEnergy);
+        OnEnergyChanged?.Invoke(currentEnergy);
     }
 }

--- a/Assets/_Project/Scripts/UI/HUDController.cs
+++ b/Assets/_Project/Scripts/UI/HUDController.cs
@@ -7,10 +7,12 @@ public class HUDController : MonoBehaviour
     public TextMeshProUGUI ammoText;
     public TextMeshProUGUI healthText;
     public TextMeshProUGUI staminaText;
+    public TextMeshProUGUI energyText;
 
     InventoryManager inventory;
     PlayerHealth health;
     PlayerStamina stamina;
+    PlayerEnergy energy;
 
     void OnEnable()
     {
@@ -20,6 +22,8 @@ public class HUDController : MonoBehaviour
             health = FindObjectOfType<PlayerHealth>();
         if (stamina == null)
             stamina = FindObjectOfType<PlayerStamina>();
+        if (energy == null)
+            energy = FindObjectOfType<PlayerEnergy>();
 
         if (inventory != null)
             inventory.OnInventoryChanged += UpdateWeaponUI;
@@ -27,10 +31,13 @@ public class HUDController : MonoBehaviour
             health.OnHealthChanged += UpdateHealthUI;
         if (stamina != null)
             stamina.OnStaminaChanged += UpdateStaminaUI;
+        if (energy != null)
+            energy.OnEnergyChanged += UpdateEnergyUI;
 
         UpdateWeaponUI();
         if (health != null) UpdateHealthUI(health.currentHealth);
         if (stamina != null) UpdateStaminaUI(stamina.currentStamina);
+        if (energy != null) UpdateEnergyUI(energy.currentEnergy);
     }
 
     void OnDisable()
@@ -41,6 +48,8 @@ public class HUDController : MonoBehaviour
             health.OnHealthChanged -= UpdateHealthUI;
         if (stamina != null)
             stamina.OnStaminaChanged -= UpdateStaminaUI;
+        if (energy != null)
+            energy.OnEnergyChanged -= UpdateEnergyUI;
     }
 
     void UpdateWeaponUI()
@@ -68,5 +77,11 @@ public class HUDController : MonoBehaviour
     {
         if (staminaText != null && stamina != null)
             staminaText.text = "ST: " + value + "/" + stamina.maxStamina;
+    }
+
+    void UpdateEnergyUI(int value)
+    {
+        if (energyText != null && energy != null)
+            energyText.text = "EN: " + value + "/" + energy.maxEnergy;
     }
 }

--- a/Assets/_Project/Scripts/UI/PrefabFactory.cs
+++ b/Assets/_Project/Scripts/UI/PrefabFactory.cs
@@ -115,6 +115,13 @@ public static class PrefabFactory
         var text = textGO.AddComponent<TMPro.TextMeshProUGUI>();
         var manager = go.AddComponent<ScoreManager>();
         manager.textoPontos = text;
+
+        var energyGO = new GameObject("EnergyText");
+        energyGO.transform.SetParent(go.transform);
+        var energyText = energyGO.AddComponent<TMPro.TextMeshProUGUI>();
+        var hud = go.AddComponent<HUDController>();
+        hud.energyText = energyText;
+
         return go;
     }
 


### PR DESCRIPTION
## Summary
- show energy value in HUD and factory-created HUD
- notify listeners when energy changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867459710708323bddee06996623d32