### PR TITLE
Fix Unity project metadata and version

### DIFF
--- a/Assets/_Project/Scripts/Player/CameraFollow.cs.meta
+++ b/Assets/_Project/Scripts/Player/CameraFollow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 852d1b6789f14e948d3342e2b3579383

--- a/Assets/_Project/Scripts/Player/InventoryManager.cs.meta
+++ b/Assets/_Project/Scripts/Player/InventoryManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 79b8b613e51a4985b98032289a0f2a3b

--- a/Assets/_Project/Scripts/Player/PlayerMovement.cs.meta
+++ b/Assets/_Project/Scripts/Player/PlayerMovement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3dbdca48b9e84eeea962e980b03b5bd0

--- a/Assets/_Project/Scripts/Player/PlayerStamina.cs.meta
+++ b/Assets/_Project/Scripts/Player/PlayerStamina.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5edc06cbcc984f1b96c35afb50967ce1

--- a/Assets/_Project/Scripts/Projectiles/ProjectilePool.cs.meta
+++ b/Assets/_Project/Scripts/Projectiles/ProjectilePool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4fead8ca34343c0a68462ca1fdaf413

--- a/Assets/_Project/Scripts/Systems/BossTrigger.cs.meta
+++ b/Assets/_Project/Scripts/Systems/BossTrigger.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8f1275cdc43b432d8317fb49872e4193

--- a/Assets/_Project/Scripts/Systems/GameManager.cs.meta
+++ b/Assets/_Project/Scripts/Systems/GameManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7882c8afaeda484c8c2f2fded8d34ee4

--- a/Assets/_Project/Scripts/Systems/ProgressoFase.cs.meta
+++ b/Assets/_Project/Scripts/Systems/ProgressoFase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ef34c461dc564bb480c01e07c8fd134e

--- a/Assets/_Project/Scripts/Systems/SaveSystem.cs.meta
+++ b/Assets/_Project/Scripts/Systems/SaveSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 878f021866c247a39ba96ecb49b95972

--- a/Assets/_Project/Scripts/Systems/ShopManager.cs.meta
+++ b/Assets/_Project/Scripts/Systems/ShopManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 089f104ab788478298e03bd8bc7c7445

--- a/Assets/_Project/Scripts/UI/PrefabFactory.cs.meta
+++ b/Assets/_Project/Scripts/UI/PrefabFactory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c2c98b3f3cd457ba7d8ba4657f0245b

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.1.5f1
-m_EditorVersionWithRevision: 6000.1.5f1 (923722cbbcfc)
+m_EditorVersion: 2022.3.0f1
+m_EditorVersionWithRevision: 2022.3.0f1 (000000000000)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Assets/
    git clone https://github.com/zArgonaut/against-oblivion.git
    ```
 2. Abra com o Unity.
-   - Requer Unity na versão 6000.1.5f1 (verifique em `ProjectSettings/ProjectVersion.txt`).
+   - Requer Unity na versão 2022.3.0f1 (verifique em `ProjectSettings/ProjectVersion.txt`).
 3. Navegue até `Assets/_Project/Scenes/` e crie a cena inicial `MainMenu.unity` (ou execute-a se já existir).
 
 


### PR DESCRIPTION
## Summary
- add missing `.meta` files for scripts
- set Unity version to 2022.3.0f1
- update README with the correct editor version
